### PR TITLE
Use `python-dotenv` for enviroment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ venv/
 .idea/
 staticfiles/
 *.dump
+.env
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/TomeOfBattle/settings.py
+++ b/TomeOfBattle/settings.py
@@ -1,17 +1,12 @@
 """
 Django settings for TomeOfBattle project.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/1.7/topics/settings/
-
-For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.7/ref/settings/
 """
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-
 import django_heroku
+from dotenv import load_dotenv
+
+load_dotenv()
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ importlib-metadata==1.6.0
 Markdown==3.2.2
 pathspec==0.8.0
 psycopg2==2.8.5
+python-dotenv==0.13.0
 pytz==2020.1
 regex==2020.5.14
 sqlparse==0.3.1


### PR DESCRIPTION
There are more projects that need saving from the cedar14 stack, we need to clean up the local environment variables.

`python-dotenv` is a tool for that.