### PR TITLE
Update the .gitignore file to account for IntelliJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,13 @@
 
 db.sqlite3
 venv/
-.idea/
 staticfiles/
 *.dump
 .env
+
+# IDE
+.idea/
+*.iml
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
I'm using the Java IntelliJ these days for license reasons, looks like the IDE cruft has changed.