### PR TITLE
Pin Vue version to 2.6.14

### DIFF
--- a/search_engine/templates/search.html
+++ b/search_engine/templates/search.html
@@ -252,10 +252,6 @@
 {% endblock %}
 
 {% block scripts %}
-    {% if debug %}
-        <script src="https://unpkg.com/vue"></script>
-    {% else %}
-        <script src="https://unpkg.com/vue@2.4.2/dist/vue.min.js"></script>
-    {% endif %}
+    <script src="https://unpkg.com/vue@2.6.14/dist/vue.min.js"></script>
     <script src="{% static "search.js" %}"></script>
 {% endblock %}


### PR DESCRIPTION
Because the development version default is now 3.X, which is incompatible